### PR TITLE
M8-T3: Leptos app shell with routing

### DIFF
--- a/crates/adapters/adapter_dashboard_leptos/src/components/mod.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/components/mod.rs
@@ -1,0 +1,3 @@
+mod nav;
+
+pub use nav::Nav;

--- a/crates/adapters/adapter_dashboard_leptos/src/components/nav.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/components/nav.rs
@@ -1,0 +1,17 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Nav() -> impl IntoView {
+    view! {
+        <nav>
+            <ul>
+                <li><a href="/">"Home"</a></li>
+                <li><a href="/devices">"Devices"</a></li>
+                <li><a href="/entities">"Entities"</a></li>
+                <li><a href="/areas">"Areas"</a></li>
+                <li><a href="/events">"Events"</a></li>
+                <li><a href="/automations">"Automations"</a></li>
+            </ul>
+        </nav>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/lib.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/lib.rs
@@ -1,11 +1,34 @@
 use leptos::prelude::*;
+use leptos_router::{
+    components::{Route, Router, Routes},
+    path,
+};
+
+mod components;
+mod pages;
+
+use components::Nav;
+use pages::{
+    Areas, AutomationDetail, Automations, Devices, Entities, EntityDetail, Events, Home, NotFound,
+};
 
 #[component]
 pub fn App() -> impl IntoView {
     view! {
-        <div>
-            <h1>"Hello minihub"</h1>
-            <p>"Welcome to the minihub dashboard"</p>
-        </div>
+        <Router>
+            <Nav/>
+            <main>
+                <Routes fallback=|| view! { <NotFound/> }>
+                    <Route path=path!("/") view=Home/>
+                    <Route path=path!("/devices") view=Devices/>
+                    <Route path=path!("/entities") view=Entities/>
+                    <Route path=path!("/entities/:id") view=EntityDetail/>
+                    <Route path=path!("/areas") view=Areas/>
+                    <Route path=path!("/events") view=Events/>
+                    <Route path=path!("/automations") view=Automations/>
+                    <Route path=path!("/automations/:id") view=AutomationDetail/>
+                </Routes>
+            </main>
+        </Router>
     }
 }

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/areas.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/areas.rs
@@ -1,0 +1,11 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Areas() -> impl IntoView {
+    view! {
+        <div>
+            <h1>"Areas"</h1>
+            <p>"Area list will appear here"</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/automation_detail.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/automation_detail.rs
@@ -1,0 +1,15 @@
+use leptos::prelude::*;
+use leptos_router::hooks::use_params_map;
+
+#[component]
+pub fn AutomationDetail() -> impl IntoView {
+    let params = use_params_map();
+    let id = move || params.read().get("id").unwrap_or_default();
+
+    view! {
+        <div>
+            <h1>"Automation Detail"</h1>
+            <p>"Automation ID: " {id}</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/automations.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/automations.rs
@@ -1,0 +1,11 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Automations() -> impl IntoView {
+    view! {
+        <div>
+            <h1>"Automations"</h1>
+            <p>"Automation list will appear here"</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/devices.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/devices.rs
@@ -1,0 +1,11 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Devices() -> impl IntoView {
+    view! {
+        <div>
+            <h1>"Devices"</h1>
+            <p>"Device list will appear here"</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/entities.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/entities.rs
@@ -1,0 +1,11 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Entities() -> impl IntoView {
+    view! {
+        <div>
+            <h1>"Entities"</h1>
+            <p>"Entity list will appear here"</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/entity_detail.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/entity_detail.rs
@@ -1,0 +1,15 @@
+use leptos::prelude::*;
+use leptos_router::hooks::use_params_map;
+
+#[component]
+pub fn EntityDetail() -> impl IntoView {
+    let params = use_params_map();
+    let id = move || params.read().get("id").unwrap_or_default();
+
+    view! {
+        <div>
+            <h1>"Entity Detail"</h1>
+            <p>"Entity ID: " {id}</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/events.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/events.rs
@@ -1,0 +1,11 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Events() -> impl IntoView {
+    view! {
+        <div>
+            <h1>"Events"</h1>
+            <p>"Event log will appear here"</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/home.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/home.rs
@@ -1,0 +1,11 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Home() -> impl IntoView {
+    view! {
+        <div>
+            <h1>"Home"</h1>
+            <p>"Welcome to minihub dashboard"</p>
+        </div>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/mod.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/mod.rs
@@ -1,0 +1,19 @@
+mod areas;
+mod automation_detail;
+mod automations;
+mod devices;
+mod entities;
+mod entity_detail;
+mod events;
+mod home;
+mod not_found;
+
+pub use areas::Areas;
+pub use automation_detail::AutomationDetail;
+pub use automations::Automations;
+pub use devices::Devices;
+pub use entities::Entities;
+pub use entity_detail::EntityDetail;
+pub use events::Events;
+pub use home::Home;
+pub use not_found::NotFound;

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/not_found.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/not_found.rs
@@ -1,0 +1,14 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn NotFound() -> impl IntoView {
+    view! {
+        <div>
+            <h1>"404 - Page Not Found"</h1>
+            <p>"The page you are looking for does not exist."</p>
+            <p>
+                <a href="/">"Go back to home"</a>
+            </p>
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary

Implements M8-T3 from TASKS.md: Set up Leptos router with all required routes, nav component, and 404 fallback page.

## Changes

- Set up Leptos Router with 8 routes:
  - `/` (home)
  - `/devices`
  - `/entities`
  - `/entities/:id` (with dynamic parameter)
  - `/areas`
  - `/events`
  - `/automations`
  - `/automations/:id` (with dynamic parameter)
- Created Nav component with navigation links to all main pages
- Added NotFound (404) fallback page for non-existent routes
- Created placeholder page components for all routes
- Client-side navigation works without full page reloads

## Testing

- `cargo check --target wasm32-unknown-unknown` passes
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings` passes
- `trunk build` successfully compiles to WASM
- Workspace check/clippy passes

## DoD Checklist

- [x] Leptos router with routes: /, /devices, /entities, /entities/{id}, /areas, /events, /automations, /automations/{id}
- [x] Nav component with links
- [x] 404 fallback page
- [x] Client-side navigation works without full reloads
- [x] `cargo check --all` passes
- [x] `cargo clippy` passes (no warnings)

## Files Changed

13 files changed, 176 insertions(+), 4 deletions(-)

## Next Steps

After this PR merges, M8-T4 (Home page + API client) can begin.