### PR TITLE
feat(M8-T5): Device + entity list pages

### DIFF
--- a/crates/adapters/adapter_dashboard_leptos/src/components/device_table.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/components/device_table.rs
@@ -1,0 +1,66 @@
+//! Device table component for displaying a list of devices.
+
+use leptos::prelude::*;
+use leptos_router::components::A;
+use minihub_domain::device::Device;
+
+/// A table displaying a list of devices.
+#[component]
+pub fn DeviceTable(
+    /// The list of devices to display.
+    devices: Vec<Device>,
+) -> impl IntoView {
+    if devices.is_empty() {
+        view! {
+            <p>"No devices found."</p>
+        }
+        .into_any()
+    } else {
+        view! {
+            <table>
+                <thead>
+                    <tr>
+                        <th>"Name"</th>
+                        <th>"Manufacturer"</th>
+                        <th>"Model"</th>
+                        <th>"Integration"</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {devices.into_iter().map(|device| {
+                        view! {
+                            <DeviceRow device/>
+                        }
+                    }).collect::<Vec<_>>()}
+                </tbody>
+            </table>
+        }
+        .into_any()
+    }
+}
+
+/// A single row in the device table.
+#[component]
+fn DeviceRow(
+    /// The device to display.
+    device: Device,
+) -> impl IntoView {
+    let device_id = device.id.to_string();
+    let name = device.name;
+    let manufacturer = device.manufacturer.unwrap_or_else(|| "—".to_string());
+    let model = device.model.unwrap_or_else(|| "—".to_string());
+    let integration = device.integration;
+
+    view! {
+        <tr>
+            <td>
+                <A href=format!("/devices/{}", device_id)>
+                    {name}
+                </A>
+            </td>
+            <td>{manufacturer}</td>
+            <td>{model}</td>
+            <td>{integration}</td>
+        </tr>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/components/entity_table.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/components/entity_table.rs
@@ -1,0 +1,86 @@
+//! Entity table component for displaying a list of entities.
+
+use leptos::prelude::*;
+use leptos_router::components::A;
+use minihub_domain::entity::{Entity, EntityState};
+
+/// A table displaying a list of entities.
+#[component]
+pub fn EntityTable(
+    /// The list of entities to display.
+    entities: Vec<Entity>,
+) -> impl IntoView {
+    if entities.is_empty() {
+        view! {
+            <p>"No entities found."</p>
+        }
+        .into_any()
+    } else {
+        view! {
+            <table>
+                <thead>
+                    <tr>
+                        <th>"Entity ID"</th>
+                        <th>"Name"</th>
+                        <th>"State"</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {entities.into_iter().map(|entity| {
+                        view! {
+                            <EntityRow entity/>
+                        }
+                    }).collect::<Vec<_>>()}
+                </tbody>
+            </table>
+        }
+        .into_any()
+    }
+}
+
+/// A single row in the entity table.
+#[component]
+fn EntityRow(
+    /// The entity to display.
+    entity: Entity,
+) -> impl IntoView {
+    let entity_id = entity.id.to_string();
+    let entity_id_str = entity.entity_id;
+    let friendly_name = entity.friendly_name;
+    let state = entity.state;
+
+    view! {
+        <tr>
+            <td>
+                <A href=format!("/entities/{}", entity_id)>
+                    {entity_id_str}
+                </A>
+            </td>
+            <td>{friendly_name}</td>
+            <td>
+                <StateBadge state/>
+            </td>
+        </tr>
+    }
+}
+
+/// A badge displaying an entity state with appropriate styling.
+#[component]
+fn StateBadge(
+    /// The entity state to display.
+    state: EntityState,
+) -> impl IntoView {
+    let state_class = match state {
+        EntityState::On => "badge-on",
+        EntityState::Off => "badge-off",
+        EntityState::Unknown => "badge-unknown",
+        EntityState::Unavailable => "badge-unavailable",
+    };
+    let state_str = state.to_string();
+
+    view! {
+        <span class=format!("badge {}", state_class)>
+            {state_str}
+        </span>
+    }
+}

--- a/crates/adapters/adapter_dashboard_leptos/src/components/mod.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/components/mod.rs
@@ -1,5 +1,9 @@
+mod device_table;
+mod entity_table;
 mod nav;
 mod stat_card;
 
+pub use device_table::DeviceTable;
+pub use entity_table::EntityTable;
 pub use nav::Nav;
 pub use stat_card::StatCard;

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/devices.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/devices.rs
@@ -1,7 +1,7 @@
 use leptos::prelude::*;
-use leptos_router::components::A;
 
 use crate::api;
+use crate::components::DeviceTable;
 
 /// Devices page displaying all devices in a table.
 #[component]
@@ -14,47 +14,9 @@ pub fn Devices() -> impl IntoView {
             <Suspense fallback=move || view! { <p>"Loading devices…"</p> }>
                 {move || {
                     devices.read().as_deref().map(|result| match result {
-                        Ok(devices_list) => {
-                            if devices_list.is_empty() {
-                                view! {
-                                    <p>"No devices found."</p>
-                                }.into_any()
-                            } else {
-                                view! {
-                                    <table>
-                                        <thead>
-                                            <tr>
-                                                <th>"Name"</th>
-                                                <th>"Manufacturer"</th>
-                                                <th>"Model"</th>
-                                                <th>"Integration"</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {devices_list.iter().map(|device| {
-                                                let device_id = device.id.to_string();
-                                                let name = device.name.clone();
-                                                let manufacturer = device.manufacturer.clone().unwrap_or_else(|| "—".to_string());
-                                                let model = device.model.clone().unwrap_or_else(|| "—".to_string());
-                                                let integration = device.integration.clone();
-                                                view! {
-                                                    <tr>
-                                                        <td>
-                                                            <A href=format!("/devices/{}", device_id)>
-                                                                {name}
-                                                            </A>
-                                                        </td>
-                                                        <td>{manufacturer}</td>
-                                                        <td>{model}</td>
-                                                        <td>{integration}</td>
-                                                    </tr>
-                                                }
-                                            }).collect::<Vec<_>>()}
-                                        </tbody>
-                                    </table>
-                                }.into_any()
-                            }
-                        }
+                        Ok(devices_list) => view! {
+                            <DeviceTable devices=devices_list.clone()/>
+                        }.into_any(),
                         Err(err) => view! {
                             <p class="error">{"Failed to load devices: "} {err.to_string()}</p>
                         }.into_any(),

--- a/crates/adapters/adapter_dashboard_leptos/src/pages/entities.rs
+++ b/crates/adapters/adapter_dashboard_leptos/src/pages/entities.rs
@@ -1,8 +1,7 @@
 use leptos::prelude::*;
-use leptos_router::components::A;
 
 use crate::api;
-use minihub_domain::entity::EntityState;
+use crate::components::EntityTable;
 
 /// Entities page displaying all entities in a table with state badges.
 #[component]
@@ -15,49 +14,9 @@ pub fn Entities() -> impl IntoView {
             <Suspense fallback=move || view! { <p>"Loading entities…"</p> }>
                 {move || {
                     entities.read().as_deref().map(|result| match result {
-                        Ok(entities_list) => {
-                            if entities_list.is_empty() {
-                                view! {
-                                    <p>"No entities found."</p>
-                                }.into_any()
-                            } else {
-                                view! {
-                                    <table>
-                                        <thead>
-                                            <tr>
-                                                <th>"Entity ID"</th>
-                                                <th>"Name"</th>
-                                                <th>"State"</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {entities_list.iter().map(|entity| {
-                                                let entity_id = entity.id.to_string();
-                                                let entity_id_str = entity.entity_id.clone();
-                                                let friendly_name = entity.friendly_name.clone();
-                                                let state_class = state_badge_class(&entity.state);
-                                                let state_str = entity.state.to_string();
-                                                view! {
-                                                    <tr>
-                                                        <td>
-                                                            <A href=format!("/entities/{}", entity_id)>
-                                                                {entity_id_str}
-                                                            </A>
-                                                        </td>
-                                                        <td>{friendly_name}</td>
-                                                        <td>
-                                                            <span class=format!("badge {}", state_class)>
-                                                                {state_str}
-                                                            </span>
-                                                        </td>
-                                                    </tr>
-                                                }
-                                            }).collect::<Vec<_>>()}
-                                        </tbody>
-                                    </table>
-                                }.into_any()
-                            }
-                        }
+                        Ok(entities_list) => view! {
+                            <EntityTable entities=entities_list.clone()/>
+                        }.into_any(),
                         Err(err) => view! {
                             <p class="error">{"Failed to load entities: "} {err.to_string()}</p>
                         }.into_any(),
@@ -65,15 +24,5 @@ pub fn Entities() -> impl IntoView {
                 }}
             </Suspense>
         </div>
-    }
-}
-
-/// Return CSS class name for state badge based on entity state.
-fn state_badge_class(state: &EntityState) -> &'static str {
-    match state {
-        EntityState::On => "badge-on",
-        EntityState::Off => "badge-off",
-        EntityState::Unknown => "badge-unknown",
-        EntityState::Unavailable => "badge-unavailable",
     }
 }


### PR DESCRIPTION
## M8-T5: Device + Entity List Pages

Implements interactive device and entity list pages for the Leptos dashboard.

### Changes

#### Device List Page
- Fetches devices from `/api/devices` and displays in table
- Columns: Name, Manufacturer, Model, Integration
- Links to device detail pages
- Shows "—" for missing manufacturer/model
- Handles loading, error, and empty states

#### Entity List Page
- Fetches entities from `/api/entities` and displays in table
- Columns: Entity ID, Name, State
- State badges with CSS classes:
  - `badge-on` for on state
  - `badge-off` for off state
  - `badge-unknown` for unknown state
  - `badge-unavailable` for unavailable state
- Links to entity detail pages
- Handles loading, error, and empty states

### Testing

- ✅ `cargo clippy --all-targets --all-features -- -D warnings` passes
- ✅ `cargo test --all` passes
- ✅ `trunk build --release` succeeds (WASM compilation)
- ✅ All quality gates met

### Commits

1. `f38d3be`: Device list page with table
2. `b9565ce`: Entity list page with state badges

### Definition of Done

- [x] Device list page fetches and displays all devices in a table
- [x] Entity list page fetches and displays all entities with state badges
- [x] Links to detail pages (routes already defined)
- [x] Loading and error states handled
- [x] All quality gates pass
- [x] Atomic commits created

Closes #M8-T5